### PR TITLE
New feature - Target value display logic in VueUiSparkbar component

### DIFF
--- a/TestingArena/ArenaVueUiSparkbar.vue
+++ b/TestingArena/ArenaVueUiSparkbar.vue
@@ -12,7 +12,7 @@ const dataset = ref([
         rounding: 2,
         suffix: "%",
         prefix: 'P',
-        target: 1000,
+        target: 1000
     },
     {
         name: "popularity",
@@ -39,6 +39,8 @@ const model = ref([
     { key: 'style.layout.independant', def: true, type: 'checkbox'},
     { key: 'style.layout.percentage', def: true, type: 'checkbox'},
     { key: 'style.layout.target', def: 200, type: 'number', min: 50, max: 200},
+    { key: 'style.layout.showTargetValue', def: false, type: 'checkbox'},
+    { key: 'style.layout.showTargetValueText', def: '', type: 'text'},
     { key: 'style.gutter.backgroundColor', def: '#e1e5e8', type: 'color'},
     { key: 'style.gutter.opacity', def: 100, type: 'range', min: 0, max: 100},
     { key: 'style.bar.gradient.show', def: true, type: 'checkbox'},

--- a/cypress/fixtures/sparkbar.json
+++ b/cypress/fixtures/sparkbar.json
@@ -62,6 +62,14 @@
           "suffix": "%",
           "prefix": "v.",
           "rounding": 0
+        },
+        {
+          "name": "KPI 10",
+          "value": 10,
+          "target": 1000,
+          "suffix": "%",
+          "prefix": "v.",
+          "rounding": 0
         }
       ],
     "config": {
@@ -71,7 +79,8 @@
             "layout": {
                 "independant": true,
                 "percentage": true,
-                "target": 0
+                "showTargetValue": true,
+                "showTargetValueText": "to"
             },
             "gutter": {
                 "backgroundColor": "#e1e5e8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "vue-data-ui",
-  "version": "2.2.74",
+  "version": "2.2.78",
   "lockfileVersion": 3,
   "requires": true,
   "dev": true,
   "packages": {
     "": {
       "name": "vue-data-ui",
-      "version": "2.2.74",
+      "version": "2.2.78",
       "license": "MIT",
       "devDependencies": {
         "@vitejs/plugin-vue": "^4.2.3",
@@ -19,7 +19,8 @@
         "simple-git": "^3.24.0",
         "vite": "^4.5.3",
         "vitest": "^0.34.1",
-        "vue": "^3.3.4"
+        "vue": "^3.3.4",
+        "vue-data-ui": "file:../vue-data-ui"
       }
     },
     "node_modules/@babel/parser": {
@@ -3667,6 +3668,10 @@
         "@vue/server-renderer": "3.3.4",
         "@vue/shared": "3.3.4"
       }
+    },
+    "node_modules/vue-data-ui": {
+      "resolved": "",
+      "link": true
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/src/components/vue-ui-sparkbar.cy.js
+++ b/src/components/vue-ui-sparkbar.cy.js
@@ -16,11 +16,11 @@ describe('<VueUiSparkbar />', () => {
         }
       });
 
-      for(let i = 0; i < fixture.dataset.length; i += 1) {
+      for (let i = 0; i < fixture.dataset.length; i += 1) {
         cy.get(`[data-cy="sparkbar-svg-${i}"]`).should('exist');
         cy.get(`[data-cy="sparkbar-name-${i}"]`)
           .should('exist')
-          .contains(fixture.dataset[i].name)
+          .contains(fixture.dataset[i].name);
 
         cy.get(`[data-cy="sparkbar-value-${i}"]`)
           .should('exist')
@@ -29,8 +29,29 @@ describe('<VueUiSparkbar />', () => {
             v: fixture.dataset[i].value,
             s: fixture.dataset[i].suffix,
             r: fixture.dataset[i].rounding
-          }))
+          }));
+
+        if (fixture.config.style.layout.showTargetValue) {
+          const targetValueText = fixture.config.style.layout.showTargetValueText;
+          const target = fixture.config.style.layout.target ?? fixture.dataset[i].target ?? 0;
+
+          const formattedValue = dataLabel({
+            p: fixture.dataset[i].prefix || '',
+            v: target,
+            s: fixture.dataset[i].suffix || '',
+            r: fixture.dataset[i].rounding || 0
+          });
+
+          const expectedText = `${targetValueText} ${formattedValue}`.trim();
+
+          cy.get(`[data-cy="sparkbar-target-value-${i}"]`)
+            .should('exist')
+            .invoke('text')
+            .then((text) => {
+              expect(text.trim()).to.eq(expectedText);
+            });
+        }
       }
     });
   });
-})
+});

--- a/src/components/vue-ui-sparkbar.vue
+++ b/src/components/vue-ui-sparkbar.vue
@@ -163,6 +163,13 @@ function ratioTo(bar) {
     }
 }
 
+function getTarget(bar) {
+  if (sparkbarConfig.value.style.layout.independant) {
+    return bar.target || sparkbarConfig.value.style.layout.target;
+  }
+  return sparkbarConfig.value.style.layout.target;
+}
+
 const emits = defineEmits(['selectDatapoint'])
 
 function selectDatapoint(datapoint, index) {
@@ -188,6 +195,19 @@ function selectDatapoint(datapoint, index) {
                             r: bar.rounding || 0
                         })}}
                     </span>
+                    <span
+                        :data-cy="`sparkbar-target-value-${i}`"
+                        v-if="sparkbarConfig.style.layout.showTargetValue"
+                        >
+                        {{ ' ' + sparkbarConfig.style.layout.showTargetValueText }}  
+                        {{ dataLabel({
+                            p: bar.prefix || '',
+                            v: getTarget(bar),
+                            s: bar.suffix || '',
+                            r: bar.rounding || 0
+                        })}}
+                        </span>
+
                 </div>
                 <svg :xmlns="XMLNS" :data-cy="`sparkbar-svg-${i}`" :viewBox="`0 0 ${svg.width} ${svg.height}`" width="100%">
                     <defs>

--- a/src/default_configs.json
+++ b/src/default_configs.json
@@ -2662,7 +2662,9 @@
             "layout": {
                 "independant": true,
                 "percentage": true,
-                "target": 0
+                "target": 0,
+                "showTargetValue": false,
+                "showTargetValueText": ""
             },
             "gutter": {
                 "backgroundColor": "#e1e5e8",

--- a/types/vue-data-ui.d.ts
+++ b/types/vue-data-ui.d.ts
@@ -1446,6 +1446,7 @@ declare module 'vue-data-ui' {
                 independant?: boolean;
                 percentage?: boolean;
                 target?: number;
+                showTargetValue?: boolean;
             };
             gutter?: {
                 backgroundColor?: string;

--- a/types/vue-data-ui.d.ts
+++ b/types/vue-data-ui.d.ts
@@ -1447,6 +1447,7 @@ declare module 'vue-data-ui' {
                 percentage?: boolean;
                 target?: number;
                 showTargetValue?: boolean;
+                showTargetValueText?: string;
             };
             gutter?: {
                 backgroundColor?: string;


### PR DESCRIPTION
## Summary:
Added conditional logic to display target value in `<VueUiSparkbar />` component.

## Details:
Updated the component to show target value based on `showTargetValue` and `showTargetValueText` configuration.
Adjusted logic to determine whether to use `bar.target` or` config.style.layout.target` for displaying target value, depending on the independant setting.

## Impact:
This change ensures the target value is displayed correctly according to the configuration settings, improving the component’s flexibility and accuracy in displaying target values.

## Discussion:
I'd ask you to test it too, here I've tested it with the independent target and also with the target coming from config.

TBD: How do you plan to deal with translations in the components - if there are fixed texts?
I ask because currently, we pass texts to the component, via config or dataset, but what if we want to leave the message fixed, for example, “to” in the config of the showTargetValueText being changed to the respective translation in the user's language, only dealing with the translation in the client?

This time I removed the local dependencies (I think 😁)