### PR TITLE
New feature - Title options and custom slot in VueUiSparkbar component

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,14 +353,14 @@ From the dataset you pass into the props, this component will produce the most a
 
 ### Mini charts
 
-| Name                  | dataset type                       | config type                 | emits / exposed methods | slots             | custom tooltip | themes |
-| --------------------- | ---------------------------------- | --------------------------- | ----------------------- | ----------------- | -------------- | ------ |
-| `VueUiSparkline`      | `VueUiSparklineDatasetItem[]`      | `VueUiSparklineConfig`      | `@selectDatapoint`      | `#svg`, `#before` | ❌             | ✅     |
-| `VueUiSparkbar`       | `VueUiSparkbarDatasetItem[]`       | `VueUiSparkbarConfig`       | `@selectDatapoint`      | `#data-label`     | ❌             | ✅     |
-| `VueUiSparkStackbar`  | `VueUiSparkStackbarDatasetItem[]`  | `VueUiSparkStackbarConfig`  | `@selectDatapoint`      | ❌                | ❌             | ✅     |
-| `VueUiSparkHistogram` | `VueUiSparkHistogramDatasetItem[]` | `VueUiSparkHistogramConfig` | `@selectDatapoint`      | ❌                | ❌             | ✅     |
-| `VueUiSparkGauge`     | `VueUiSparkGaugeDataset`           | `VueUiSparkGaugeConfig`     | ❌                      | ❌                | ❌             | ✅     |
-| `VueUiSparkTrend`     | `number[]`                         | `VueUiSparkTrendConfig`     | ❌                      | ❌                | ❌             | ✅     |
+| Name                  | dataset type                       | config type                 | emits / exposed methods | slots                      | custom tooltip | themes |
+| --------------------- | ---------------------------------- | --------------------------- | ----------------------- | -------------------------- | -------------- | ------ |
+| `VueUiSparkline`      | `VueUiSparklineDatasetItem[]`      | `VueUiSparklineConfig`      | `@selectDatapoint`      | `#svg`, `#before`          | ❌             | ✅     |
+| `VueUiSparkbar`       | `VueUiSparkbarDatasetItem[]`       | `VueUiSparkbarConfig`       | `@selectDatapoint`      | `#data-label`, `#title`    | ❌             | ✅     |
+| `VueUiSparkStackbar`  | `VueUiSparkStackbarDatasetItem[]`  | `VueUiSparkStackbarConfig`  | `@selectDatapoint`      | ❌                         | ❌             | ✅     |
+| `VueUiSparkHistogram` | `VueUiSparkHistogramDatasetItem[]` | `VueUiSparkHistogramConfig` | `@selectDatapoint`      | ❌                         | ❌             | ✅     |
+| `VueUiSparkGauge`     | `VueUiSparkGaugeDataset`           | `VueUiSparkGaugeConfig`     | ❌                      | ❌                         | ❌             | ✅     |
+| `VueUiSparkTrend`     | `number[]`                         | `VueUiSparkTrendConfig`     | ❌                      | ❌                         | ❌             | ✅     |
 
 ### Charts
 

--- a/TestingArena/ArenaVueUiSparkbar.vue
+++ b/TestingArena/ArenaVueUiSparkbar.vue
@@ -115,6 +115,13 @@ const step = ref(0)
         
         <template #VDUI-local>
             <LocalVueDataUi component="VueUiSparkbar" :dataset="dataset" :config="config" :key="`VDUI-lodal_${step}`">
+                <template #title="{ title }">
+                    <div style="width:100%;">
+                        {{ title.title }}
+                        {{ title.subtitle }}
+                    </div>
+                </template>
+
                 <template #data-label="{ bar }">
                     <div style="width:100%">
                         {{ bar.name }}: {{ bar.valueLabel }} to {{ bar.targetLabel }}
@@ -125,6 +132,13 @@ const step = ref(0)
         
         <template #build>
             <VueUiSparkbar :dataset="dataset" :config="config" :key="`build_${step}`">
+                <template #title="{ title }">
+                    <div style="width:100%;">
+                        {{ title.title }}
+                        {{ title.subtitle }}
+                    </div>
+                </template>
+
                 <template #data-label="{ bar }">
                     <div style="width:100%">
                         {{ bar.name }}: {{ bar.valueLabel }} to {{ bar.targetLabel }}
@@ -135,6 +149,13 @@ const step = ref(0)
         
         <template #VDUI-build>
             <VueDataUi component="VueUiSparkbar" :dataset="dataset" :config="config" :key="`VDUI-build_${step}`">
+                <template #title="{ title }">
+                    <div style="width:100%;">
+                        {{ title.title }}
+                        {{ title.subtitle }}
+                    </div>
+                </template>
+
                 <template #data-label="{ bar }">
                     <div style="width:100%">
                         {{ bar.name }}: {{ bar.valueLabel }} to {{ bar.targetLabel }}

--- a/TestingArena/ArenaVueUiSparkbar.vue
+++ b/TestingArena/ArenaVueUiSparkbar.vue
@@ -53,6 +53,14 @@ const model = ref([
     { key: 'style.labels.name.bold', def: false, type: 'checkbox'},
     { key: 'style.labels.value.show', def: true, type: 'checkbox'},
     { key: 'style.labels.value.bold', def: true, type: 'checkbox'},
+    { key: 'style.title.text', def: 'Lorem ipsum dolor sic amet', type: 'text'},
+    { key: 'style.title.color', def: '#1A1A1A', type: 'color'},
+    { key: 'style.title.fontSize', def: 20, type: 'number', min: 8, max: 48},
+    { key: 'style.title.bold', def: true, type: 'checkbox'},
+    { key: 'style.title.subtitle.text', def: 'At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis', type: 'text'},
+    { key: 'style.title.subtitle.color', def: '#CCCCCC', type: 'color'},
+    { key: 'style.title.subtitle.fontSize', def: 16, type: 'range', min: 8, max: 48},
+    { key: 'style.title.subtitle.bold', def: false, type: 'checkbox'},
     { key: 'style.gap', def: 4, type: 'number', min: 0, max: 24}
 ])
 
@@ -90,6 +98,13 @@ const step = ref(0)
         
         <template #local>
             <LocalVueUiSparkbar :dataset="dataset" :config="config" :key="`local_${step}`">
+                <template #title="{ title }">
+                    <div style="width:100%;">
+                        {{ title.title }}
+                        {{ title.subtitle }}
+                    </div>
+                </template>
+
                 <template #data-label="{ bar }">
                     <div style="width:100%">
                         {{ bar.name }}: {{ bar.valueLabel }} to {{ bar.targetLabel }}

--- a/cypress/fixtures/sparkbar.json
+++ b/cypress/fixtures/sparkbar.json
@@ -1,111 +1,125 @@
 {
-    "dataset": [
-        {
-          "name": "KPI 1",
-          "value": 88.88,
-          "suffix": "%",
-          "prefix": "v.",
-          "rounding": 1
-        },
-        {
-          "name": "KPI 2",
-          "value": 77.77,
-          "suffix": "%",
-          "prefix": "v.",
-          "rounding": 2
-        },
-        {
-          "name": "KPI 3",
-          "value": 66.66,
-          "suffix": "%",
-          "prefix": "v.",
-          "rounding": 0
-        },
-        {
-          "name": "KPI 4",
-          "value": 55.55,
-          "suffix": "%",
-          "prefix": "v.",
-          "rounding": 0
-        },
-        {
-          "name": "KPI 5",
-          "value": 44.44,
-          "suffix": "%",
-          "prefix": "v.",
-          "rounding": 0
-        },
-        {
-          "name": "KPI 6",
-          "value": 33.33,
-          "suffix": "%",
-          "prefix": "v.",
-          "rounding": 0
-        },
-        {
-          "name": "KPI 7",
-          "value": 22.22,
-          "suffix": "%",
-          "prefix": "v.",
-          "rounding": 0
-        },
-        {
-          "name": "KPI 8",
-          "value": 11.11,
-          "suffix": "%",
-          "prefix": "v.",
-          "rounding": 0
-        },
-        {
-          "name": "KPI 9",
-          "value": 0,
-          "suffix": "%",
-          "prefix": "v.",
-          "rounding": 0
-        },
-        {
-          "name": "KPI 10",
-          "value": 10,
-          "target": 1000,
-          "suffix": "%",
-          "prefix": "v.",
-          "rounding": 0
-        }
-      ],
-    "config": {
-        "style": {
-            "backgroundColor": "#FFFFFF",
-            "fontFamily": "inherit",
-            "layout": {
-                "independant": true,
-                "percentage": true,
-                "showTargetValue": true,
-                "targetValueText": "to"
-            },
-            "gutter": {
-                "backgroundColor": "#e1e5e8"
-            },
-            "bar": {
-                "gradient": {
-                    "show": true,
-                    "intensity": 40,
-                    "underlayerColor": "#FFFFFF"
-                }
-            },
-            "labels": {
-                "fontSize": 16,
-                "name": {
-                    "position": "top",
-                    "width": "100%",
-                    "color": "#2D353C",
-                    "bold": false
-                },
-                "value": {
-                    "show": true,
-                    "bold": true
-                }
-            },
-            "gap": 4
-        }
+  "dataset": [
+    {
+      "name": "KPI 1",
+      "value": 88.88,
+      "suffix": "%",
+      "prefix": "v.",
+      "rounding": 1
+    },
+    {
+      "name": "KPI 2",
+      "value": 77.77,
+      "suffix": "%",
+      "prefix": "v.",
+      "rounding": 2
+    },
+    {
+      "name": "KPI 3",
+      "value": 66.66,
+      "suffix": "%",
+      "prefix": "v.",
+      "rounding": 0
+    },
+    {
+      "name": "KPI 4",
+      "value": 55.55,
+      "suffix": "%",
+      "prefix": "v.",
+      "rounding": 0
+    },
+    {
+      "name": "KPI 5",
+      "value": 44.44,
+      "suffix": "%",
+      "prefix": "v.",
+      "rounding": 0
+    },
+    {
+      "name": "KPI 6",
+      "value": 33.33,
+      "suffix": "%",
+      "prefix": "v.",
+      "rounding": 0
+    },
+    {
+      "name": "KPI 7",
+      "value": 22.22,
+      "suffix": "%",
+      "prefix": "v.",
+      "rounding": 0
+    },
+    {
+      "name": "KPI 8",
+      "value": 11.11,
+      "suffix": "%",
+      "prefix": "v.",
+      "rounding": 0
+    },
+    {
+      "name": "KPI 9",
+      "value": 0,
+      "suffix": "%",
+      "prefix": "v.",
+      "rounding": 0
+    },
+    {
+      "name": "KPI 10",
+      "value": 10,
+      "target": 1000,
+      "suffix": "%",
+      "prefix": "v.",
+      "rounding": 0
     }
+  ],
+  "config": {
+    "style": {
+      "backgroundColor": "#FFFFFF",
+      "fontFamily": "inherit",
+      "title": {
+        "text": "Default Title",
+        "fontSize": 20,
+        "color": "#333333",
+        "bold": true,
+        "margin": "10px",
+        "textAlign": "center",
+        "subtitle": {
+          "text": "Default Subtitle",
+          "fontSize": 16,
+          "color": "#666666",
+          "bold": false
+        }
+      },
+      "layout": {
+        "independant": true,
+        "percentage": true,
+        "showTargetValue": true,
+        "targetValueText": "to"
+      },
+      "gutter": {
+        "backgroundColor": "#e1e5e8"
+      },
+      "bar": {
+        "gradient": {
+          "show": true,
+          "intensity": 40,
+          "underlayerColor": "#FFFFFF"
+        }
+      },
+      "labels": {
+        "fontSize": 16,
+        "name": {
+          "position": "top",
+          "width": "100%",
+          "color": "#2D353C",
+          "bold": false
+        },
+        "value": {
+          "show": true,
+          "bold": true
+        }
+      },
+      "gap": 4
+    }
+  }
 }

--- a/documentation/installation.md
+++ b/documentation/installation.md
@@ -129,14 +129,14 @@ From the dataset you pass into the props, this component will produce the most a
 
 ### Mini charts
 
-| Name                  | dataset type                       | config type                 | emits / exposed methods | slots             | custom tooltip | themes |
-| --------------------- | ---------------------------------- | --------------------------- | ----------------------- | ----------------- | -------------- | ------ |
-| `VueUiSparkline`      | `VueUiSparklineDatasetItem[]`      | `VueUiSparklineConfig`      | `@selectDatapoint`      | `#svg`, `#before` | ❌             | ✅     |
-| `VueUiSparkbar`       | `VueUiSparkbarDatasetItem[]`       | `VueUiSparkbarConfig`       | `@selectDatapoint`      | `#data-label`     | ❌             | ✅     |
-| `VueUiSparkStackbar`  | `VueUiSparkStackbarDatasetItem[]`  | `VueUiSparkStackbarConfig`  | `@selectDatapoint`      | ❌                | ❌             | ✅     |
-| `VueUiSparkHistogram` | `VueUiSparkHistogramDatasetItem[]` | `VueUiSparkHistogramConfig` | `@selectDatapoint`      | ❌                | ❌             | ✅     |
-| `VueUiSparkGauge`     | `VueUiSparkGaugeDataset`           | `VueUiSparkGaugeConfig`     | ❌                      | ❌                | ❌             | ✅     |
-| `VueUiSparkTrend`     | `number[]`                         | `VueUiSparkTrendConfig`     | ❌                      | ❌                | ❌             | ✅     |
+| Name                  | dataset type                       | config type                 | emits / exposed methods | slots                       | custom tooltip | themes |
+| --------------------- | ---------------------------------- | --------------------------- | ----------------------- | --------------------------- | -------------- | ------ |
+| `VueUiSparkline`      | `VueUiSparklineDatasetItem[]`      | `VueUiSparklineConfig`      | `@selectDatapoint`      | `#svg`, `#before`           | ❌             | ✅     |
+| `VueUiSparkbar`       | `VueUiSparkbarDatasetItem[]`       | `VueUiSparkbarConfig`       | `@selectDatapoint`      | `#data-label`, `#title`     | ❌             | ✅     |
+| `VueUiSparkStackbar`  | `VueUiSparkStackbarDatasetItem[]`  | `VueUiSparkStackbarConfig`  | `@selectDatapoint`      | ❌                          | ❌             | ✅     |
+| `VueUiSparkHistogram` | `VueUiSparkHistogramDatasetItem[]` | `VueUiSparkHistogramConfig` | `@selectDatapoint`      | ❌                          | ❌             | ✅     |
+| `VueUiSparkGauge`     | `VueUiSparkGaugeDataset`           | `VueUiSparkGaugeConfig`     | ❌                      | ❌                          | ❌             | ✅     |
+| `VueUiSparkTrend`     | `number[]`                         | `VueUiSparkTrendConfig`     | ❌                      | ❌                          | ❌             | ✅     |
 
 ### Charts
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "vue-data-ui",
-  "version": "2.2.78",
+  "version": "2.2.81",
   "lockfileVersion": 3,
   "requires": true,
   "dev": true,
   "packages": {
     "": {
       "name": "vue-data-ui",
-      "version": "2.2.78",
+      "version": "2.2.81",
       "license": "MIT",
       "devDependencies": {
         "@vitejs/plugin-vue": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "vite": "^4.5.3",
     "vitest": "^0.34.1",
     "vue": "^3.3.4",
-    "simple-git": "^3.24.0",
-    "vue-data-ui": "file:../vue-data-ui"
+    "simple-git": "^3.24.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "vite": "^4.5.3",
     "vitest": "^0.34.1",
     "vue": "^3.3.4",
-    "simple-git": "^3.24.0"
+    "simple-git": "^3.24.0",
+    "vue-data-ui": "file:../vue-data-ui"
   }
 }

--- a/src/components/vue-ui-sparkbar.cy.js
+++ b/src/components/vue-ui-sparkbar.cy.js
@@ -1,5 +1,5 @@
 import { dataLabel } from '../lib';
-import VueUiSparkbar from './vue-ui-sparkbar.vue'
+import VueUiSparkbar from './vue-ui-sparkbar.vue';
 
 describe('<VueUiSparkbar />', () => {
   beforeEach(function () {
@@ -51,6 +51,49 @@ describe('<VueUiSparkbar />', () => {
               expect(text.trim()).to.eq(expectedText);
             });
         }
+      }
+    });
+  });
+
+  it('renders with custom title and subtitle using slots', function () {
+    cy.get('@fixture').then((fixture) => {
+      const customTitle = 'Custom Title';
+      const customSubtitle = 'Custom Subtitle';
+
+      cy.mount(VueUiSparkbar, {
+        props: {
+          dataset: fixture.dataset,
+          config: fixture.config
+        },
+        slots: {
+          title: `<div>
+                    <div data-cy="custom-title">${customTitle}</div>
+                    <div data-cy="custom-subtitle">${customSubtitle}</div>
+                  </div>`
+        }
+      });
+
+      cy.get('[data-cy="custom-title"]').should('exist').contains(customTitle);
+      cy.get('[data-cy="custom-subtitle"]').should('exist').contains(customSubtitle);
+      
+      cy.get('[data-cy="sparkbar-title-wrapper"]').should('not.exist');
+    });
+  });
+
+  it('renders with default title when no slot is provided', function () {
+    cy.get('@fixture').then((fixture) => {
+      cy.mount(VueUiSparkbar, {
+        props: {
+          dataset: fixture.dataset,
+          config: fixture.config
+        }
+      });
+
+      cy.get('[data-cy="sparkbar-title-wrapper"]').should('exist');
+      cy.get('[data-cy="sparkbar-title"]').should('exist').contains(fixture.config.style.title.text);
+      
+      if (fixture.config.style.title.subtitle?.text) {
+        cy.get('[data-cy="sparkbar-subtitle"]').should('exist').contains(fixture.config.style.title.subtitle.text);
       }
     });
   });

--- a/src/components/vue-ui-sparkbar.vue
+++ b/src/components/vue-ui-sparkbar.vue
@@ -180,6 +180,19 @@ function selectDatapoint(datapoint, index) {
 
 <template>
     <div :style="`width:100%; font-family:${sparkbarConfig.style.fontFamily};background:${sparkbarConfig.style.backgroundColor}`">
+       <!-- CUSTOM TITLE -->
+       <slot v-if="$slots['title']" name="title" v-bind="{ title: { ...title, title: sparkbarConfig.style.title.text, subtitle: sparkbarConfig.style.title.subtitle.text } }" />
+           
+        <!-- DEFAULT TITLE -->
+        <div data-cy="sparkbar-title-wrapper" v-if="!$slots['title'] && sparkbarConfig.style.title.text"  :style="`width:calc(100% - 12px);background:${sparkbarConfig.style.backgroundColor};margin:0 auto;margin:${sparkbarConfig.style.title.margin};padding: 0 6px;text-align:${sparkbarConfig.style.title.textAlign}`">
+            <div data-cy="sparkbar-title" :style="`font-size:${sparkbarConfig.style.title.fontSize}px;color:${sparkbarConfig.style.title.color};font-weight:${sparkbarConfig.style.title.bold ? 'bold' : 'normal'}`">
+                {{ sparkbarConfig.style.title.text }}
+            </div>
+            <div data-cy="sparkbar-subtitle" v-if="sparkbarConfig.style.title.subtitle.text" :style="`font-size:${sparkbarConfig.style.title.subtitle.fontSize}px;color:${sparkbarConfig.style.title.subtitle.color};font-weight:${sparkbarConfig.style.title.subtitle.bold ? 'bold' : 'normal'}`">
+                {{ sparkbarConfig.style.title.subtitle.text }}
+            </div>
+            
+        </div>
         <template v-for="(bar, i) in drawableDataset">
             <div v-if="isDataset" :style="`display:flex !important;${['left', 'right'].includes(sparkbarConfig.style.labels.name.position) ? 'flex-direction:row !important' : 'flex-direction:column !important'};gap:${sparkbarConfig.style.gap}px !important;${sparkbarConfig.style.labels.name.position === 'right' ? 'row-reverse !important' : ''};align-items:center;${dataset.length > 0 && i !== dataset.length - 1 ? 'margin-bottom:6px' : ''}`" @click="() => selectDatapoint(bar, i)">
                 <!-- CUSTOM DATALABEL -->

--- a/src/default_configs.json
+++ b/src/default_configs.json
@@ -2690,6 +2690,18 @@
                     "bold": true
                 }
             },
+            "title": {
+                "text": "",
+                "color": "#2D353C",
+                "fontSize": 20,
+                "bold": true,
+                "subtitle": {
+                    "color": "#A1A1A1",
+                    "text": "",
+                    "fontSize": 16,
+                    "bold": false
+                }
+            },
             "gap": 4
         }
     },

--- a/types/vue-data-ui.d.ts
+++ b/types/vue-data-ui.d.ts
@@ -1463,7 +1463,7 @@ declare module 'vue-data-ui' {
             labels?: {
                 fontSize?: number;
                 name?: {
-                    position?: "top" | "left" | "right";
+                    position?: TextAlign;
                     width?: string;
                     color?: string;
                     bold?: boolean;
@@ -1472,6 +1472,20 @@ declare module 'vue-data-ui' {
                     show?: boolean;
                     bold?: boolean;
                 }
+            },
+            title?: {
+                backgroundColor?: string;
+                text?: string;
+                fontSize?: number;
+                color?: string;
+                bold?: boolean;
+                textAlign?: TextAlign;
+                subtitle?: {
+                    text?: string;
+                    color?: string;
+                    fontSize?: number;
+                    bold?: boolean;
+                };
             },
             gap?: number;
         }


### PR DESCRIPTION
## Summary:
Added support for custom title and subtitle slots in the <VueUiSparkbar /> component.

## Details:
### Support for Custom Slots:
Added the ability to provide custom title and subtitle using the title slot in the <VueUiSparkbar /> component.
If a custom slot is provided, it will override the default title and subtitle specified in config.style.title.text and config.style.title.subtitle.text.

### Default Title and Subtitle Handling:
If no custom slot is provided, the component will render the default title and subtitle based on config.style.title.text and config.style.title.subtitle.
Improved conditional logic to check for the presence of the slot and the title text to determine which content to display.

## Impact:

These changes enhance the flexibility and customization of the <VueUiSparkbar /> component by allowing users to define their own titles and subtitles while maintaining sensible defaults. This improves the component's adaptability and provides more control over its appearance.

This revision is now focused solely on the title and subtitle changes, aligning with your updates. Let me know if there's anything else you'd like to adjust!

## Discussion:
I still don't fully understand the difference between #build and #VDUI-build. Should we apply changes to both of them?