### PR TITLE
Fix - onion animations when percentage value is more than 33%

### DIFF
--- a/src/components/vue-ui-onion.vue
+++ b/src/components/vue-ui-onion.vue
@@ -280,7 +280,7 @@ const mutableDataset = computed(() => {
 });
 
 function peelOnion(radius, percentage) {
-    const circumference = radius * (1.5 + (percentage / 100 > 1 / 3 ? 0 : 1 - percentage / 100)) * Math.PI;
+    const circumference = radius * (1.5 + 1 - percentage / 100) * Math.PI;
     const bg = radius * 1.5 * Math.PI;
     return {
         bgDashArray: `${bg} ${bg}`,


### PR DESCRIPTION
On the [documentation page for vue-ui-onion](https://vue-data-ui.graphieros.com/docs#vue-ui-onion) there is an issue with the animation.

It seems that if a dataset has data with a `percentage` higher than `33`, it will produce a flickering effect where the ring is flipping on the left-side.
This PR fixes it.

| Before | After |
|-|-|
| ![before](https://github.com/user-attachments/assets/1710e700-95d7-498d-bfb6-f0ddf0498d5a) | ![after](https://github.com/user-attachments/assets/100ab21d-82e2-44c8-929e-c03dc6524449) |

----

Maybe the intention with the ternary and the `> 1 / 3` in the code is different than what I understand and the fix is somewhere else?