### PR TITLE
Changed conflicting class names.

### DIFF
--- a/src/atoms/BaseDraggableDialog.vue
+++ b/src/atoms/BaseDraggableDialog.vue
@@ -210,12 +210,12 @@ onUnmounted(() => {
         <div 
             v-if="isOpen" 
             data-cy="draggable-dialog" 
-            class="modal vue-ui-draggable-dialog" 
+            class="vue-ui-draggable-dialog" 
             :style="modalStyle"
             @click.stop
         >
             <div 
-                class="modal-header"
+                class="vue-ui-draggable-dialog-header"
                 :style="{
                     backgroundColor: headerBg,
                     color: headerColor
@@ -243,7 +243,7 @@ onUnmounted(() => {
 
 
                 </span>
-                <span class="modal-title">
+                <span class="vue-ui-draggable-dialog-title">
                     <slot name="title"/>
                 </span>
                 <div class="draggable-dialog-actions">
@@ -253,7 +253,7 @@ onUnmounted(() => {
                     </button>
                 </div>
             </div>
-            <div :class="{ 'modal-body': !withPadding, 'modal-body-pad': withPadding}">
+            <div :class="{ 'vue-ui-draggable-dialog-body': !withPadding, 'vue-ui-draggable-dialog-body-pad': withPadding}">
                 <slot name="content" />
             </div>
             <div class="resize-handle" @mousedown.stop.prevent="initResize" @touchstart.stop.prevent="initResize" />
@@ -267,7 +267,7 @@ onUnmounted(() => {
 </template>
 
 <style scoped>
-.modal-header {
+.vue-ui-draggable-dialog-header {
     display: flex;
     align-items: center;
     user-select: none;
@@ -296,7 +296,7 @@ onUnmounted(() => {
     cursor: grabbing;
 }
 
-.modal-title {
+.vue-ui-draggable-dialog-title {
     flex: 1;
     font-weight: bold;
 }
@@ -310,14 +310,14 @@ onUnmounted(() => {
     justify-content: center;
 }
 
-.modal-body {
+.vue-ui-draggable-dialog-body {
     width: 100%;
     height: 80%;
     overflow: auto;
     transition: all 0.2s ease-in-out;
 }
 
-.modal-body-pad {
+.vue-ui-draggable-dialog-body-pad {
     padding: 0 12px;
     width: calc(100% - 24px);
     height: 80%;

--- a/src/components/vue-ui-table.vue
+++ b/src/components/vue-ui-table.vue
@@ -525,7 +525,7 @@
         <!-- CHART MODAL -->
         <div class="vue-ui-table-chart-modal" v-if="showChart && canChart"
             :style="`width: ${modalWidth}px;top:${clientY}px; left:${clientX}px;background:${FINAL_CONFIG.style.chart.modal.backgroundColor};color:${FINAL_CONFIG.style.chart.modal.color}`">
-            <div class="modal-drag-handle" @mousedown="dragMouseDown">
+            <div class="vue-ui-modal-drag-handle" @mousedown="dragMouseDown">
                 <!-- Your modal title or drag icon here -->
                 <span v-html="icons.grip"/>
                 <button class="close-chart-modal" @click="showChart = false">✖</button>
@@ -2591,7 +2591,7 @@ input.vue-ui-table-dialog-input {
     color: white;
 }
 
-.vue-ui-table-chart-modal .modal-drag-handle {
+.vue-ui-table-chart-modal .vue-ui-modal-drag-handle {
     cursor: move;
     user-select: none;
     display: flex;


### PR DESCRIPTION
This pull request focuses on standardizing the naming conventions for CSS classes related to modal dialogs and drag handles across the codebase. The changes primarily replace generic or legacy class names with more specific, component-scoped names to enhance maintainability and prevent style conflicts.

**CSS class name standardization and refactoring:**

* Updated modal dialog classes in `BaseDraggableDialog.vue` to use `vue-ui-draggable-dialog-*` prefixes instead of generic `modal-*` classes, including the container, header, title, and body elements. [[1]](diffhunk://#diff-0f608ab8af640a083caad3f509e8becee9204d6438a597609750c50fdfc948edL213-R218) [[2]](diffhunk://#diff-0f608ab8af640a083caad3f509e8becee9204d6438a597609750c50fdfc948edL246-R246) [[3]](diffhunk://#diff-0f608ab8af640a083caad3f509e8becee9204d6438a597609750c50fdfc948edL256-R256) [[4]](diffhunk://#diff-0f608ab8af640a083caad3f509e8becee9204d6438a597609750c50fdfc948edL270-R270) [[5]](diffhunk://#diff-0f608ab8af640a083caad3f509e8becee9204d6438a597609750c50fdfc948edL299-R299) [[6]](diffhunk://#diff-0f608ab8af640a083caad3f509e8becee9204d6438a597609750c50fdfc948edL313-R320)
* Replaced the chart modal drag handle class in `vue-ui-table.vue` from `modal-drag-handle` to `vue-ui-modal-drag-handle` in both the template and CSS to match the new naming convention. [[1]](diffhunk://#diff-e3e4da99842718121585edc22e064cc57a44ea608807cb1dcbfea11f8c5aefbbL528-R528) [[2]](diffhunk://#diff-e3e4da99842718121585edc22e064cc57a44ea608807cb1dcbfea11f8c5aefbbL2594-R2594)

Defect [BaseDraggableDialog - modal css class can conflict with UI libraries ](https://github.com/graphieros/vue-data-ui/issues/278#issuecomment-3584646655)