### PR TITLE
chore: fix npm badge use npmx

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![GitHub issues](https://img.shields.io/github/issues/graphieros/vue-data-ui)](https://github.com/graphieros/vue-data-ui/issues)
 [![License](https://img.shields.io/badge/license-MIT-green)](https://github.com/graphieros/vue-data-ui?tab=MIT-1-ov-file#readme)
 [![MadeWithVueJs.com shield](https://madewithvuejs.com/storage/repo-shields/4526-shield.svg)](https://madewithvuejs.com/p/vue-data-ui/shield-link)
-[![npm](https://img.shields.io/npm/dt/vue-data-ui)](https://github.com/graphieros/vue-data-ui)
+[![npm downloads](https://npmx.dev/api/registry/badge/downloads/vue-data-ui)](https://npmx.dev/package/vue-data-ui?modal=chart)
 [![GitHub Repo stars](https://img.shields.io/github/stars/graphieros/vue-data-ui)](https://github.com/graphieros/vue-data-ui)
 
 [Interactive documentation](https://vue-data-ui.graphieros.com/)


### PR DESCRIPTION
Since I noticed that the npm badge has been switched to npmx, I was wondering if you would like to switch your downloads to the same version and sync the query parameters so that you can see the download count pop-up when you open the page.

Screenshot

<img width="3828" height="1911" alt="image" src="https://github.com/user-attachments/assets/20fc938a-e750-4c1c-8f57-f701a5833cf8" />
