### PR TITLE
Fix - slugify - keep Unicode letters and numbers in slugs

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -3804,7 +3804,7 @@ export function slugify(str) {
         .toString()
         .toLowerCase()
         .replace(/\s+/g, '-') // Replace spaces with -
-        .replace(/[^\w\-]+/g, '') // Remove all non-word chars
+        .replace(/[^\p{L}\p{N}_-]+/gu, '') // Remove all non-word chars, keeping Unicode letters and numbers
         .replace(/\-\-+/g, '-') // Replace multiple - with single -
         .replace(/^-+/, '') // Trim start
         .replace(/-+$/, ''); // Trim end

--- a/tests/lib.test.js
+++ b/tests/lib.test.js
@@ -95,6 +95,7 @@ import {
     setOpacity,
     setOpacityIfWithinBBox,
     shiftHue,
+    slugify,
     srgbEncodeFromLinear,
     sumByAttribute,
     sumSeries,
@@ -4881,5 +4882,29 @@ describe('createStepperPath', () => {
             { x: NaN, y: 30, value: 30 },
         ];
         expect(createStepperPath(points)).toBe('');
+    });
+});
+
+describe('slugify', () => {
+    test('lowercases, trims and hyphenates ASCII text', () => {
+        expect(slugify('  Hello World  ')).toBe('hello-world');
+        expect(slugify('Hello   World')).toBe('hello-world');
+    });
+
+    test('keeps Unicode letters and numbers instead of dropping them', () => {
+        expect(slugify('日本語')).toBe('日本語');
+        expect(slugify('한국어')).toBe('한국어');
+        expect(slugify('Café')).toBe('café');
+        expect(slugify('Ø2')).toBe('ø2');
+    });
+
+    test('produces distinct ids for distinct non-ASCII labels', () => {
+        expect(slugify('日本')).not.toBe(slugify('한국'));
+        expect(slugify('Москва')).not.toBe(slugify('Київ'));
+    });
+
+    test('still removes punctuation and symbols', () => {
+        expect(slugify('a@b!c')).toBe('abc');
+        expect(slugify('hot 🔥 take')).toBe('hot-take');
     });
 });


### PR DESCRIPTION
### What

`slugify()` removed every non-ASCII character with `[^\w-]` (`\w` is ASCII only), so labels written in CJK, Cyrillic and similar scripts, or made up of accented letters, collapsed to an empty string:

```js
slugify('日本語') // '' before, '日本語' after
slugify('Café')  // 'caf' before, 'café' after
```

### Why it matters

`VueUiRidgeline` derives each datapoint's `id`, its legend-map key and its main gradient element id from `slugify(name)`:

- `formattedDataset` / `drawableDataset`: `const id = slugify(dp.name)`
- `createLegend`: `const id = slugify(dp.name); if (!map.has(id)) { ... }`
- template: `id="gradient-{dp.id}-{uid}"` referenced by `fill="url(#gradient-{dp.id}-{uid})"`

Since every non-ASCII name slugifies to the same empty string, two labels such as `你好` and `世界` share one id. That collapses them into a single legend entry, makes the show/hide toggle act on more than the intended series, and yields duplicate SVG gradient ids so `url(#...)` resolves to the first matching gradient.

The library already treats those scripts as valid data, for example `createWordCloudDatasetFromPlainText` detects and splits Han / Hiragana / Katakana / Hangul / Thai text, so such labels are expected input.

### Change

Match Unicode letters and numbers (`/[^\p{L}\p{N}_-]+/gu`) instead of ASCII word chars. Punctuation, symbols and emoji are still stripped, so ASCII output is unchanged:

```js
slugify('Hello World') // 'hello-world'
slugify('a@b!c')       // 'abc'
slugify('hot 🔥 take')  // 'hot-take'
```

Added unit tests in `tests/lib.test.js` for ASCII handling, Unicode preservation, distinct ids for distinct non-ASCII labels, and punctuation/symbol stripping. The full vitest suite passes.
